### PR TITLE
Add default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
+
+task :default do
+  system 'bundle exec rspec'
+end


### PR DESCRIPTION
There are many gems with default tasks, follow them.
default task executes `bundle exec rspec`