### PR TITLE
Not to use `be_valid` matcher in after block

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ require 'rspec/all_records_validator'
 
 RSpec.configure do |config|
   config.after type: :system do
-    RSpec::AllRecordsValidator.validate_all_objects {|record| expect(record).to be_valid }
+    RSpec::AllRecordsValidator.validate!
   end
 end
 ```
@@ -43,7 +43,7 @@ You can avoid validation for specific models:
 ```ruby
 RSpec.configure do |config|
   config.after type: :system do
-    RSpec::AllRecordsValidator.validate_all_objects(ignored_models: [DoNotValidatrThisModel]) {|record| expect(record).to be_valid }
+    RSpec::AllRecordsValidator.validate!(ignored_models: [DoNotValidateThisModel])
   end
 end
 ```
@@ -55,7 +55,7 @@ You can config This setting for feature spec
 ```ruby
 RSpec.configure do |config|
   config.after type: :feature do
-    RSpec::AllRecordsValidator.validate_all_objects {|record| expect(record).to be_valid }
+    RSpec::AllRecordsValidator.validate!
   end
 end
 ```

--- a/lib/rspec/all_records_validator.rb
+++ b/lib/rspec/all_records_validator.rb
@@ -4,12 +4,12 @@ require_relative "all_records_validator/version"
 
 module RSpec
   module AllRecordsValidator
-    def self.validate_all_objects(ignored_models: [])
+    def self.validate!(ignored_models: [])
       target_classes = ApplicationRecord.subclasses.reject {|klass| klass.abstract_class? || ignored_models.include?(klass) }
 
       target_classes.each do |klass|
         klass.all.each do |obj|
-          yield(obj)
+          obj.validate!
         end
       end
     end

--- a/spec/rspec/all_records_validator_spec.rb
+++ b/spec/rspec/all_records_validator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RSpec::AllRecordsValidator do
     end
 
     it 'All Records are valid' do
-      expect { RSpec::AllRecordsValidator.validate_all_objects {|record| raise StandardError if record.invalid? } }.not_to raise_error
+      expect { RSpec::AllRecordsValidator.validate! }.not_to raise_error
     end
   end
 
@@ -26,7 +26,7 @@ RSpec.describe RSpec::AllRecordsValidator do
       end
 
       it 'One record is invalid' do
-        expect { RSpec::AllRecordsValidator.validate_all_objects {|record| raise StandardError if record.invalid? } }.to raise_error(StandardError)
+        expect { RSpec::AllRecordsValidator.validate! }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
 
@@ -38,7 +38,7 @@ RSpec.describe RSpec::AllRecordsValidator do
       end
 
       it 'It ignores an abstract class records' do
-        expect { RSpec::AllRecordsValidator.validate_all_objects {|record| raise StandardError if record.invalid? } }.not_to raise_error
+        expect { RSpec::AllRecordsValidator.validate! }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
In test context, using `be_valid` is not proper way for test.
Because it fails in right check.
Test checks failing validation was always fail.
This PR update to not to use the `be_valid` and to use `validate!`.
It raises exception, it solves problem above.
