### PR TITLE
Update base settings for gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake'
-gem 'rails'
+gem 'activerecord'
 gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord
   rails
   rake
   rspec

--- a/rspec-all_records_validator.gemspec
+++ b/rspec-all_records_validator.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "validate all objects at end of system spec"
   spec.homepage      = "https://github.com/colorbox/rspec-all_records_validator"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
dependency updated rails -> activerecord
it is good for nallow dependency

fix minimum ruby version for `required_ruby_version` with CI ruby versions