### PR TITLE
Ignore model whitch without `has_many` association

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RSpec::AllRecordsValidator
 
-Check all ActiveRecord object validation after system spec.
+Check all ActiveRecord object validation which has `has_many` association after system spec.
 
 This gem is designed for: [rspec-rails](https://github.com/rspec/rspec-rails)
 

--- a/lib/rspec/all_records_validator.rb
+++ b/lib/rspec/all_records_validator.rb
@@ -5,7 +5,7 @@ require_relative "all_records_validator/version"
 module RSpec
   module AllRecordsValidator
     def self.validate!(ignored_models: [])
-      target_classes = ApplicationRecord.subclasses.reject {|klass| klass.abstract_class? || ignored_models.include?(klass) }
+      target_classes = ApplicationRecord.subclasses.reject {|klass| klass.abstract_class? || ignored_models.include?(klass) || klass.reflect_on_all_associations(:has_many).blank? }
 
       target_classes.each do |klass|
         klass.all.each do |obj|

--- a/spec/fake_app.rb
+++ b/spec/fake_app.rb
@@ -25,10 +25,26 @@ ActiveRecord::Tasks::DatabaseTasks.create_current 'test'
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end
+
 class Foo < ApplicationRecord
   validates :name, length: {maximum: 10}
+  has_many :foo_child
 end
+
+class FooChild < ApplicationRecord
+  belongs_to :foo
+end
+
 class Bar < ApplicationRecord
+  validates :name, length: {maximum: 10}
+  has_many :bar_child
+end
+
+class BarChild < ApplicationRecord
+  belongs_to :bar
+end
+
+class Baz < ApplicationRecord
   validates :name, length: {maximum: 10}
 end
 
@@ -37,14 +53,20 @@ class CreateAllTables < ActiveRecord::Migration[5.0]
   def self.up
     ActiveRecord::Base.establish_connection :test
     create_table(:foos) {|t| t.string :name; t.references :bar, foreign_key: true }
-    create_table(:bars) {|t| t.string :name; t.index :name, unique: true }
+    create_table(:foo_children) {|t| t.references :foo; t.index :name, unique: true }
+    create_table(:bars) {|t| t.references :foo; t.string :name; t.index :name, unique: true }
+    create_table(:bar_children) {|t| t.references :bar; t.index :name, unique: true }
+    create_table(:bazs) {|t| t.string :name; t.index :name, unique: true }
 
     ActiveRecord::Base.establish_connection :test
   end
 
   def self.down
-    drop_table(:foos) {|t| t.string :name }
-    drop_table(:bars) {|t| t.string :name }
+    drop_table(:foos)
+    drop_table(:foo_children)
+    drop_table(:bars)
+    drop_table(:bar_children)
+    drop_table(:bazs)
 
     ActiveRecord::Base.establish_connection :test
   end

--- a/spec/rspec/all_records_validator_spec.rb
+++ b/spec/rspec/all_records_validator_spec.rb
@@ -41,5 +41,16 @@ RSpec.describe RSpec::AllRecordsValidator do
         expect { RSpec::AllRecordsValidator.validate! }.not_to raise_error
       end
     end
+
+    context 'With invalid non-has_many model records' do
+      before do
+        baz = Baz.new(name: 'n'*11)
+        baz.save(validate: false)
+      end
+
+      it 'It ignores  model records' do
+        expect { RSpec::AllRecordsValidator.validate! }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
This gem resolve creating of unintentional invalid record with association length validation.
So it is enough to check model with `has_many` models.