### PR TITLE
Add `only_has_many` option for exclude non-has_many model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RSpec::AllRecordsValidator
 
-Check all ActiveRecord object validation which has `has_many` association after system spec.
+Check all ActiveRecord object validation after system spec.
 
 This gem is designed for: [rspec-rails](https://github.com/rspec/rspec-rails)
 
@@ -47,6 +47,17 @@ RSpec.configure do |config|
   end
 end
 ```
+
+#### Avoid validation for model whitch has no `has_many` association
+
+```ruby
+RSpec.configure do |config|
+  config.after type: :system do
+    RSpec::AllRecordsValidator.validate!(only_has_many: true)
+  end
+end
+```
+
 
 #### For feature spec
 

--- a/lib/rspec/all_records_validator.rb
+++ b/lib/rspec/all_records_validator.rb
@@ -4,8 +4,8 @@ require_relative "all_records_validator/version"
 
 module RSpec
   module AllRecordsValidator
-    def self.validate!(ignored_models: [])
-      target_classes = ApplicationRecord.subclasses.reject {|klass| klass.abstract_class? || ignored_models.include?(klass) || klass.reflect_on_all_associations(:has_many).blank? }
+    def self.validate!(ignored_models: [], only_has_many: false)
+      target_classes = ApplicationRecord.subclasses.reject {|klass| klass.abstract_class? || ignored_models.include?(klass) || (only_has_many && klass.reflect_on_all_associations(:has_many).blank?) }
 
       target_classes.each do |klass|
         klass.all.each do |obj|

--- a/spec/rspec/all_records_validator_spec.rb
+++ b/spec/rspec/all_records_validator_spec.rb
@@ -48,8 +48,16 @@ RSpec.describe RSpec::AllRecordsValidator do
         baz.save(validate: false)
       end
 
-      it 'It ignores  model records' do
-        expect { RSpec::AllRecordsValidator.validate! }.not_to raise_error
+      after do
+        Baz.first.destroy!
+      end
+
+      it 'It ignores when only_has_many is true' do
+        expect { RSpec::AllRecordsValidator.validate!(only_has_many: true) }.not_to raise_error
+      end
+
+      it 'It raise validation error when only_has_many is false' do
+        expect { RSpec::AllRecordsValidator.validate!(only_has_many: false) }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
   end


### PR DESCRIPTION
This gem purpose is detect bug for creating invalid records with assocition length validation.
Is happens only on models has `has_many` association.